### PR TITLE
allow sending view once ptt audio messages

### DIFF
--- a/src/chat/functions/sendFileMessage.ts
+++ b/src/chat/functions/sendFileMessage.ts
@@ -265,7 +265,11 @@ export async function sendFileMessage(
   let isViewOnce: boolean | undefined;
 
   if (options.type === 'audio') {
+    if(options.isPtt) {
+      isViewOnce = options.isViewOnce;
+    }
     rawMediaOptions.isPtt = options.isPtt;
+    
     rawMediaOptions.precomputedFields = await prepareAudioWaveform(
       options as any,
       file


### PR DESCRIPTION
it seems simply passing forward the isViewOnce for ptt in chat.sendFileMessage works, so allow to do that.